### PR TITLE
feat: use versioned Chart and update CRDs when upgrading

### DIFF
--- a/apps/base/traefik-hub/release.yaml
+++ b/apps/base/traefik-hub/release.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
@@ -8,6 +9,7 @@ spec:
   chart:
     spec:
       chart: traefik-hub
+      version: v2.7.0
       sourceRef:
         kind: HelmRepository
         name: traefik-hub
@@ -15,6 +17,8 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    crds: CreateReplace
   values:
     additionalArguments:
       - --hub.metrics.opentelemetry.insecure


### PR DESCRIPTION
## What does this PR do ?

1. Use a fixed version of the Traefik Hub Helm chart
2. Improve upgrade, by updating by default the CRDs

## Motivation

Avoid breaking this repo when publishing a new version of the Chart.
