### PR TITLE
fix: docker build not using proper tag

### DIFF
--- a/.github/workflows/api-server.yaml
+++ b/.github/workflows/api-server.yaml
@@ -44,7 +44,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/api-server
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=match,pattern=api-server_(v\d+.\d+.\d+)
+            type=match,pattern=api-server_(v\d+.\d+.\d+),group=1
             type=raw,value={{branch}}-{{sha}}-{{date 'X'}},enable={{is_default_branch}}
             type=ref,event=pr
       - name: build docker images


### PR DESCRIPTION
# Motivation

Fix tag following GH action documentation, see https://github.com/docker/metadata-action#typematch