### PR TITLE
fix typo in op-id name

### DIFF
--- a/apps/base/apps/flight/spec.yaml
+++ b/apps/base/apps/flight/spec.yaml
@@ -23,7 +23,7 @@ data:
       /flights:
         get:
           summary: Retrieve flights
-          operationId: gettFlights
+          operationId: getFlights
           tags:
             - flights
           parameters:


### PR DESCRIPTION
This PR:

- Fix typo in `operationID` name